### PR TITLE
TEL-4189 Updates security-git-hooks pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         name: Fix missing end-of-file line returns
         exclude: repository.yaml|tests/unit/test-data/
   - repo: https://github.com/hmrc/security-git-hooks
-    rev: release/1.9.0
+    rev: release/1.10.0
     hooks:
       - id: secrets_filecontent
         name: Checking staged files for sensitive content


### PR DESCRIPTION
What we have done
--

Updated the hook to a version that pulls in setuptools under python 3.12, to fix "No module named 'pkg_resources'" errors.

References
--

1. Fix described here https://github.com/hmrc/security-git-hooks/pull/24
2. https://jira.tools.tax.service.gov.uk/browse/TEL-4189

Evidence of work
--

1. Run 'pre-commit  run --all-files --verbose secrets_filecontent'
3. **Assert that** it passes

Collaborators
--

Co-authored by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
