### PR TITLE
TEL-4189 Updates cruft template for security-git-hooks pre-commit hook

### DIFF
--- a/{{cookiecutter.canary_repo_name_formatted}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.canary_repo_name_formatted}}/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
         args: [-ll, -c, .bandit]
         language_version: python3
   - repo: https://github.com/hmrc/security-git-hooks
-    rev: release/1.9.0
+    rev: release/1.10.0
     hooks:
       - id: secrets_filecontent
         name: Checking staged files for sensitive content


### PR DESCRIPTION
What we have done
--

Updated the hook to a version that pulls in setuptools under python 3.12, to fix "No module named 'pkg_resources" errors.

References
--

1. Fix described here https://github.com/hmrc/security-git-hooks/pull/24
2. https://jira.tools.tax.service.gov.uk/browse/TEL-4189

Evidence of work
--

1. Run 'pre-commit  run --all-files --verbose secrets_filecontent'
2. **Assert that** it passes

Collaborators
--

Co-authored by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
