### PR TITLE
TEL-4189 Updates Docker Python to use artifactory

### DIFF
--- a/{{cookiecutter.canary_repo_name_formatted}}/Dockerfile
+++ b/{{cookiecutter.canary_repo_name_formatted}}/Dockerfile
@@ -6,8 +6,8 @@ COPY requirements.txt requirements-tests.txt setup.cfg /var/task/
 
 RUN python -m venv venv && \
   source ./venv/bin/activate && \
-  pip install --upgrade pip && \
-  pip install --requirement requirements-tests.txt --target "/var/task"
+  PIP_INDEX_URL=https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple pip install --upgrade pip && \
+  PIP_INDEX_URL=https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple pip install --requirement requirements-tests.txt --target "/var/task"
 
 COPY src tests /var/task/
 

--- a/{{cookiecutter.canary_repo_name_formatted}}/bin/entrypoint.sh
+++ b/{{cookiecutter.canary_repo_name_formatted}}/bin/entrypoint.sh
@@ -25,6 +25,7 @@ apt-get -y upgrade
 # Install test requirements
 python -m venv "${VENV_NAME}"
 source ./"${VENV_NAME}"/bin/activate
+export PIP_INDEX_URL=https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple
 pip install --upgrade pip
 pip install --requirement "${REQUIREMENTS_FILE}"
 


### PR DESCRIPTION
Bunch of builds blocked on this

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4189

Risks
--

Have I gone about this the right way?

Collaboration
--

Co-authored by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
